### PR TITLE
feat: Implement two-column layout for Join Us form

### DIFF
--- a/joinus/index.html
+++ b/joinus/index.html
@@ -17,100 +17,104 @@
       </div>
 
       <form id="join-form">
-        <!-- Row: Name, Email, Phone -->
-        <div class="form-row two-column-row">
-          <div class="form-field-wrapper">
-            <label for="name" data-en="Name" data-es="Nombre">Name</label>
-            <input type="text" id="name" name="name" placeholder="Enter your name" data-placeholder-en="Enter your name" data-placeholder-es="Ingrese su Nombre" />
-          </div>
+        <div class="form-columns-wrapper"> <!-- New wrapper for two columns -->
+          <!-- Column 1 -->
+          <div class="form-column">
+            <div class="form-row"> <!-- Removed two-column-row from here -->
+              <div class="form-field-wrapper">
+                <label for="name" data-en="Name" data-es="Nombre">Nombre</label>
+                <input type="text" id="name" name="name" placeholder="Enter your name" data-placeholder-en="Enter your name" data-placeholder-es="Ingrese su Nombre" />
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-field-wrapper">
+                <label for="email" data-en="Email" data-es="Correo Electrónico">Correo Electrónico</label>
+                <input type="email" id="email" name="email" placeholder="Enter your email" data-placeholder-en="Enter your email" data-placeholder-es="Ingrese su Correo Electrónico" />
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-field-wrapper">
+                <label for="phone" data-en="Phone" data-es="Teléfono">Teléfono</label>
+                <input type="tel" id="phone" name="phone" placeholder="Enter your phone" data-placeholder-en="Enter your phone" data-placeholder-es="Ingrese su Teléfono" />
+              </div>
+            </div>
 
-          <div class="form-field-wrapper">
-            <label for="email" data-en="Email" data-es="Correo Electrónico">Email</label>
-            <input type="email" id="email" name="email" placeholder="Enter your email" data-placeholder-en="Enter your email" data-placeholder-es="Ingrese su Correo Electrónico" />
-          </div>
+            <div class="form-section" data-section="Skills">
+              <div class="section-header">
+                <h2 data-en="Skills" data-es="Habilidades">Skills</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
+            </div>
 
-          <div class="form-field-wrapper">
-            <label for="phone" data-en="Phone" data-es="Teléfono">Phone</label>
-            <input type="tel" id="phone" name="phone" placeholder="Enter your phone" data-placeholder-en="Enter your phone" data-placeholder-es="Ingrese su Teléfono" />
-          </div>
-
-          <!-- Optional: Add an empty div for spacing if only 3 items, or let justify-content handle it -->
-          <!-- <div class="form-field-wrapper"></div> -->
-        </div>
-
-        <!-- Dynamic Sections -->
-        <div class="form-section" data-section="Skills">
-          <div class="section-header">
-            <h2 data-en="Skills" data-es="Habilidades">Skills</h2>
-            <div>
-              <button type="button" class="circle-btn add">+</button>
-              <button type="button" class="circle-btn remove">−</button>
+            <div class="form-section" data-section="Education">
+              <div class="section-header">
+                <h2 data-en="Education" data-es="Educación">Education</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
             </div>
           </div>
-          <div class="inputs"></div>
-          <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
-          <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
-        </div>
 
-        <div class="form-section" data-section="Education">
-          <div class="section-header">
-            <h2 data-en="Education" data-es="Educación">Education</h2>
-            <div>
-              <button type="button" class="circle-btn add">+</button>
-              <button type="button" class="circle-btn remove">−</button>
+          <!-- Column 2 -->
+          <div class="form-column">
+            <div class="form-section" data-section="Continued Education">
+              <div class="section-header">
+                <h2 data-en="Continued Education" data-es="Educación Continua">Continued Education</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
+            </div>
+
+            <div class="form-section" data-section="Certification">
+              <div class="section-header">
+                <h2 data-en="Certification" data-es="Certificación">Certification</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
+            </div>
+
+            <div class="form-section" data-section="Hobbies">
+              <div class="section-header">
+                <h2 data-en="Hobbies" data-es="Pasatiempos">Hobbies</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
+            </div>
+
+            <div class="form-row"> <!-- Comments section moved to column 2 -->
+              <label for="comment" data-en="Tell us about yourself" data-es="Cuéntanos sobre ti">Cuéntanos sobre ti</label>
+              <textarea id="comment" name="comment" rows="4" data-placeholder-en="Tell us about yourself..." data-placeholder-es="Cuéntanos sobre ti..."></textarea>
             </div>
           </div>
-          <div class="inputs"></div>
-          <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
-          <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
         </div>
 
-        <div class="form-section" data-section="Continued Education">
-          <div class="section-header">
-            <h2 data-en="Continued Education" data-es="Educación Continua">Continued Education</h2>
-            <div>
-              <button type="button" class="circle-btn add">+</button>
-              <button type="button" class="circle-btn remove">−</button>
-            </div>
-          </div>
-          <div class="inputs"></div>
-          <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
-          <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
-        </div>
-
-        <div class="form-section" data-section="Certification">
-          <div class="section-header">
-            <h2 data-en="Certification" data-es="Certificación">Certification</h2>
-            <div>
-              <button type="button" class="circle-btn add">+</button>
-              <button type="button" class="circle-btn remove">−</button>
-            </div>
-          </div>
-          <div class="inputs"></div>
-          <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
-          <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
-        </div>
-
-        <div class="form-section" data-section="Hobbies">
-          <div class="section-header">
-            <h2 data-en="Hobbies" data-es="Pasatiempos">Hobbies</h2>
-            <div>
-              <button type="button" class="circle-btn add">+</button>
-              <button type="button" class="circle-btn remove">−</button>
-            </div>
-          </div>
-          <div class="inputs"></div>
-          <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
-          <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
-        </div>
-
-        <!-- Comments -->
-        <div class="form-row">
-          <label for="comment" data-en="Tell us about yourself" data-es="Cuéntanos sobre ti">Tell us about yourself</label>
-          <textarea id="comment" name="comment" rows="4" data-placeholder-en="Tell us about yourself..." data-placeholder-es="Cuéntanos sobre ti..."></textarea>
-        </div>
-
-        <!-- Submit -->
+        <!-- Submit button remains outside the columns, but inside the form -->
         <div class="form-footer">
           <button type="submit" class="submit-button" data-en="Submit" data-es="Enviar">Submit</button>
         </div>

--- a/joinus/style.css
+++ b/joinus/style.css
@@ -195,6 +195,29 @@ textarea {
   box-sizing: border-box;
 }
 
+/* New styles for the overall two-column form layout */
+.form-columns-wrapper {
+  display: flex;
+  flex-wrap: wrap; /* Allow wrapping for responsiveness */
+  gap: 2rem; /* Space between columns */
+  align-items: flex-start; /* Align items to the top of each column */
+}
+
+.form-column {
+  flex: 1; /* Each column takes equal width */
+  min-width: 300px; /* Minimum width before wrapping on smaller screens */
+  display: flex;
+  flex-direction: column;
+  gap: 1rem; /* Space between items within a column */
+}
+
+.form-column .form-row,
+.form-column .form-section {
+  width: 100%; /* Ensure items within a column take full width of the column */
+  margin-bottom: 0; /* Remove default margin-bottom if set by .form-row or .form-section */
+}
+/* End of new styles */
+
 .form-field-wrapper label {
     display: block;
     margin-bottom: 0.25rem;


### PR DESCRIPTION
Refactors the Join Us form page (joinus/index.html and joinus/style.css) to display form elements in a two-column layout.

Key changes:
- Modified HTML structure to use a main flex container with two child column containers.
- Distributed form sections and fields across these two columns.
- Updated Spanish field headers and data-es attributes for:
  - Name (Nombre)
  - Email (Correo Electrónico)
  - Phone (Teléfono)
  - Tell us about yourself (Cuéntanos sobre ti)
- Added CSS using flexbox to manage the two-column layout, ensuring vertical alignment (items start at the top of each column) and horizontal distribution.
- Ensured the layout is responsive, with columns stacking on smaller screens.