### PR TITLE
Remove "Skip to main content" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@
   <link rel="icon" href="assets/favicon.ico">
 </head>
 <body class="landing-page dark-theme">
-    <a href="#services" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to main content</a>
     <header class="site-header">
         <div class="header-content">
             <h1 class="main-header-text" data-en="OPS" data-es="OPS">OPS</h1>


### PR DESCRIPTION
The "Skip to main content" link was an invisible element that was flagged by an accessibility audit. This commit removes the link from index.html.